### PR TITLE
chromeos-cr50-dev: Fix build

### DIFF
--- a/meta-chromeos-base/recipes-chromeos/chromeos-cr50-dev/chromeos-cr50-dev-0.0.1/0001-ec-Fix-DEBUG-variable-in-usb_updater-Makefile.patch
+++ b/meta-chromeos-base/recipes-chromeos/chromeos-cr50-dev/chromeos-cr50-dev-0.0.1/0001-ec-Fix-DEBUG-variable-in-usb_updater-Makefile.patch
@@ -1,0 +1,36 @@
+From: Brian Norris <briannorris@chromium.org>
+Date: Fri, 2 Sep 2022 13:40:17 -0700
+Subject: [PATCH] ec: Fix DEBUG "variable" in usb_updater Makefile
+
+DEBUG is not the way to refer to a variable in a Makefile expression;
+$(DEBUG) is.
+
+Also, imitate the =1 check from extra/rma_reset/Makefile.
+
+BUG=none
+TEST=build
+
+Change-Id: Ic71be497ca83041dfdedf63c10e7c74b38c05bc8
+Signed-off-by: Brian Norris <briannorris@chromium.org>
+---
+ extra/usb_updater/Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/extra/usb_updater/Makefile b/extra/usb_updater/Makefile
+index 04adfff4dd38..f1ec4f8b0e46 100644
+--- a/extra/usb_updater/Makefile
++++ b/extra/usb_updater/Makefile
+@@ -19,10 +19,10 @@ CFLAGS  := -std=gnu99 \
+         -Wredundant-decls \
+         -Wmissing-declarations
+ 
+-ifeq (DEBUG,)
+-CFLAGS += -O3
+-else
++ifeq ($(DEBUG),1)
+ CFLAGS += -O0
++else
++CFLAGS += -O3
+ endif
+ 
+ #

--- a/meta-chromeos-base/recipes-chromeos/chromeos-cr50-dev/chromeos-cr50-dev-0.0.1/0002-ec-Ignore-Wunused-result.patch
+++ b/meta-chromeos-base/recipes-chromeos/chromeos-cr50-dev/chromeos-cr50-dev-0.0.1/0002-ec-Ignore-Wunused-result.patch
@@ -1,0 +1,27 @@
+From: Brian Norris <briannorris@chromium.org>
+Date: Fri, 2 Sep 2022 14:04:11 -0700
+Subject: [PATCH] ec: Ignore -Wunused-result
+
+| gsctool.c:1986:2: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
+|         getline(&password_copy, &copy_len, stdin);
+|         ^~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Brian Norris <briannorris@chromium.org>
+---
+ extra/usb_updater/Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/extra/usb_updater/Makefile b/extra/usb_updater/Makefile
+index f1ec4f8b0e46..c5446c8f7539 100644
+--- a/extra/usb_updater/Makefile
++++ b/extra/usb_updater/Makefile
+@@ -17,7 +17,8 @@ CFLAGS  := -std=gnu99 \
+         -Wundef \
+         -Wsign-compare \
+         -Wredundant-decls \
+-        -Wmissing-declarations
++        -Wmissing-declarations \
++        -Wno-unused-result
+ 
+ ifeq ($(DEBUG),1)
+ CFLAGS += -O0

--- a/meta-chromeos-base/recipes-chromeos/chromeos-cr50-dev/chromeos-cr50-dev_0.0.1.bb
+++ b/meta-chromeos-base/recipes-chromeos/chromeos-cr50-dev/chromeos-cr50-dev_0.0.1.bb
@@ -5,7 +5,9 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${CHROMEOS_COMMON_LICENSE_DIR}/BSD-Google;md5=29eff1da2c106782397de85224e6e6bc"
 
 inherit pkgconfig
-require recipes-chromeos/chromiumos-platform/chromiumos-platform-ec.inc
+
+SRC_URI += "git://chromium.googlesource.com/chromiumos/platform/ec;protocol=https;branch=cr50_stab;destsuffix=src/platform/ec;name=chromiumos-platform-ec"
+SRCREV_chromiumos-platform-ec = "9f0ed15c133c1ee33de032da69ba045fdbae9516"
 
 A_IMAGE = "cr50.prod.ro.A.0.0.11"
 B_IMAGE = "cr50.prod.ro.B.0.0.11"
@@ -15,6 +17,17 @@ SRC_URI += "\
 "
 SRC_URI[a.sha256sum] = "e8ea56f804038c492d8e40d941ad89bb083e2dc51e13889cd12fc7676127692d"
 SRC_URI[b.sha256sum] = "c618947c73f2bd225c465ca0aea6c2b35c737cef7c93a89fea238681f042b268"
+
+SRC_URI += "\
+    file://0001-ec-Fix-DEBUG-variable-in-usb_updater-Makefile.patch \
+"
+
+# | gsctool.c:1986:2: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
+# |         getline(&password_copy, &copy_len, stdin);
+# |         ^~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SRC_URI += "\
+    file://0002-ec-Ignore-Wunused-result.patch \
+"
 
 S = "${WORKDIR}/src/platform/ec"
 B = "${WORKDIR}/build"
@@ -55,13 +68,13 @@ do_compile() {
     set_build_env
     export BOARD=cr50
     oe_runmake -C extra/usb_updater clean
-    oe_runmake -C extra/usb_updater
+    oe_runmake -C extra/usb_updater gsctool
 }
 
 do_install() {
     install -d ${D}${sbindir}
-    install -m 0744 ${S}/extra/usb_updater/gsctool ${D}${sbindir}
-    install -m 0744 ${S}/util/chargen ${D}${sbindir}
+    install -m 0755 ${S}/extra/usb_updater/gsctool ${D}${sbindir}
+    install -m 0755 ${S}/util/chargen ${D}${sbindir}
 
     if ! ${@bb.utils.contains('PACKAGECONFIG', 'reef', 'true', 'false', d)} ; then
         bbplain "Not installing Cr50 binaries"

--- a/meta-chromeos-base/recipes-chromeos/chromeos-cr50/chromeos-cr50_0.0.1.bb
+++ b/meta-chromeos-base/recipes-chromeos/chromeos-cr50/chromeos-cr50_0.0.1.bb
@@ -19,6 +19,7 @@ PACKAGES:remove = "${PN}-dev"
 
 # Cannot have chromeos-cr50-dev as that collides with an automatically generated sub-package of this recipe
 RDEPENDS:${PN} += "chromeos-cr50-dev"
+INSANE_SKIP:${PN} = "dev-deps"
 
 PACKAGECONFIG ??= ""
 


### PR DESCRIPTION
* point at cr50_stab branch, not main branch
* really build gsctool, not generic updater target
* port DEBUG variable fix, to stop using -O0
* add custom -Wno-unused-result, since this seems to be a new clang
  warning we haven't addressed in the main repo yet
* Get 755 perms, not 744

Signed-off-by: Brian Norris <briannorris@chromium.org>